### PR TITLE
[@mantine/hooks] use-viewport-size: Fix typo in the event listener options object name

### DIFF
--- a/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
+++ b/src/mantine-hooks/src/use-viewport-size/use-viewport-size.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState, useEffect } from 'react';
 import { useWindowEvent } from '../use-window-event/use-window-event';
 
-const eventListerOptions = {
+const eventListenerOptions = {
   passive: true,
 };
 


### PR DESCRIPTION
## Purpose
- Change `eventListerOptions` to `eventListenerOptions`